### PR TITLE
Fix mobile TOC behavior.

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -546,6 +546,23 @@ footer.site-footer .back-top{
   padding: 14px;
   margin-bottom: 16px;
 }
+.projet-hf .toc-drawer {
+  display: none;
+  margin-top: 10px;
+}
+.projet-hf .toc-drawer.open {
+  display: block;
+}
+.projet-hf .toc-drawer a {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: #4b5563;
+}
+.projet-hf .toc-drawer a.active {
+  background: #e8f1ff;
+  color: #0b5ed7;
+}
 .projet-hf .toc-drawer a.active {
   border-color: #cfe0ff;
   color: #0b5ed7;
@@ -758,12 +775,19 @@ footer.site-footer .back-top{
 @media (max-width: 980px) {
   .projet-hf .layout { grid-template-columns: 1fr; }
   .projet-hf .toc-panel { display: none; }
-  .projet-hf .toc-mobile { display: block; }
+  .projet-hf .toc-mobile {
+    display: block;
+    position: sticky;
+    top: 0px;
+    z-index: 20;
+    background: #ffffff;
+  }
   .projet-hf .hero { grid-template-columns: 1fr; }
   .projet-hf .hf-actions { flex-wrap: wrap; }
   .projet-hf .budget-cards { display: grid; }
   .projet-hf table.budget-table { display: none; }
   .projet-hf .chart-grid { flex-direction: column; }
+  .projet-hf .reveal { opacity: 1; transform: none; transition: none; }
 }
 
 @media (max-width: 700px) {

--- a/script/script.js
+++ b/script/script.js
@@ -57,13 +57,20 @@ document.addEventListener("DOMContentLoaded", () => {
   const tocToggle = document.getElementById("tocToggle");
   const tocDrawer = document.getElementById("tocDrawer");
   if (tocToggle && tocDrawer) {
+    tocDrawer.setAttribute("hidden", "");
     tocToggle.addEventListener("click", () => {
       const isOpen = tocDrawer.classList.toggle("open");
+      if (isOpen) {
+        tocDrawer.removeAttribute("hidden");
+      } else {
+        tocDrawer.setAttribute("hidden", "");
+      }
       tocToggle.setAttribute("aria-expanded", String(isOpen));
     });
     tocDrawer.querySelectorAll("a").forEach((link) => {
       link.addEventListener("click", () => {
         tocDrawer.classList.remove("open");
+        tocDrawer.setAttribute("hidden", "");
         tocToggle.setAttribute("aria-expanded", "false");
       });
     });


### PR DESCRIPTION
Make mobile summary sticky at top, hide drawer by default, and disable text reveal transitions on small screens.